### PR TITLE
Fixed chrome decryption error for chrome 139.0.7258.128 x64

### DIFF
--- a/decrypt.py
+++ b/decrypt.py
@@ -164,7 +164,8 @@ def decrypt_data(encrypted_junk, key):
             tag = encrypted_junk[-16:]
             plain_text = AES.new(key, AES.MODE_GCM, nonce)
             text = plain_text.decrypt(cipher_text)
-            return text[32:].decode('utf-8')
+            return text.decode('utf-8')
+            # return text[32:].decode('utf-8')
         except Exception as e:
             print("Error: Could not decrypt password")
             print(e)


### PR DESCRIPTION
The decryption of v20 password entries wasn't working for chrome 139.0.7258.128 x64.
Not sure if this was due to changes in the browser, but this pull request should fix it.

v10 entries from the most recent edge version still won't decrypt for me, but I'm currently digging deeper as to why. Maybe you have an idea what the reason might be...

For now just a chrome fix. :)

Thanks for the awesome work, much appreciated! 