### PR TITLE
[FIX] memory leaks in GetBrowserFile

### DIFF
--- a/cookie-monster-bof.c
+++ b/cookie-monster-bof.c
@@ -37,6 +37,8 @@ WINBASEAPI int __cdecl MSVCRT$memcmp(const void *_Buf1,const void *_Buf2,size_t 
 WINBASEAPI char* __cdecl  MSVCRT$strncpy (char * __dst, const char * __src, size_t __n);
 WINBASEAPI char* __cdecl  MSVCRT$strncat (char * _Dest,const char * _Source, size_t __n);
 DECLSPEC_IMPORT int WINAPI MSVCRT$strcmp(const char*, const char*);
+WINBASEAPI wchar_t *__cdecl MSVCRT$wcsncpy(wchar_t * __restrict__ _Dest, const wchar_t * __restrict__ _Source, size_t _Count);
+WINBASEAPI int __cdecl MSVCRT$_wcsicmp(const wchar_t *_Str1, const wchar_t *_Str2);
 WINBASEAPI BOOL  WINAPI   CRYPT32$CryptUnprotectData (DATA_BLOB *pDataIn, LPWSTR *ppszDataDescr, DATA_BLOB *pOptionalEntropy, PVOID pvReserved, CRYPTPROTECT_PROMPTSTRUCT *pPromptStruct, DWORD dwFlags, DATA_BLOB *pDataOut);
 WINBASEAPI HGLOBAL WINAPI KERNEL32$GlobalFree (HGLOBAL hMem);
 WINBASEAPI HANDLE WINAPI  KERNEL32$CreateToolhelp32Snapshot(DWORD dwFlags,DWORD th32ProcessID);


### PR DESCRIPTION
During some of testings i found that `GetBrowserFile` fails to properly free allocated resources, which could result into memory exhaustion.
There's also some other small potential memory leaks i noticed but haven't yet taken a proper look at, but this is the severed one as it allocates a huge chunk of memory and never frees it ( see images below ).
<img width="1133" height="445" alt="Before" src="https://github.com/user-attachments/assets/6d83855f-783e-46ab-a6e3-08b9b7dbe270" />
<img width="786" height="65" alt="MemLeak" src="https://github.com/user-attachments/assets/2e488a61-8877-4eb3-b103-ed89b85f6f71" />
